### PR TITLE
Fix to include correct paths for files in tarball

### DIFF
--- a/elpa-mirror.el
+++ b/elpa-mirror.el
@@ -304,7 +304,10 @@ Or else, user will be asked to provide the output directory."
                                   (elpamr--executable-find "tar")
                                   " cf "
                                   (elpamr--output-fullpath dir) ".tar --exclude=\"*.elc\" --exclude=\"*~\" "
-                                  (elpamr--input-fullpath dir)))))
+                                  " -C "
+                                  package-user-dir
+                                  " "
+                                  dir))))
 
           ;; for windows
           (if elpamr-debug (message "tar-cmd=%s" tar-cmd))


### PR DESCRIPTION
The paths in the tarball for package foo should be something like:

```
foo/foo-autoloads.el
[...]
```

Previous code created paths like this:

`home/fred/.emacs.d/elpa/foo/foo-autoloads.el`

Which made the tarball packages in the mirror unusable. 

Note that this change requires the tar command to support the `-C` option. This is fine on GNU tar and BSD tar, but historically not on all tar commands.