### PR TITLE
Don't go through the shell when running tar (rebased and fixed)

### DIFF
--- a/elpa-mirror.el
+++ b/elpa-mirror.el
@@ -180,6 +180,33 @@ If NO-CONVERTION is t,  it's UNIX path."
           (elpamr--get-dependency final-pkg)
           (elpamr--clean-package-description (elpamr--get-summary final-pkg))))
 
+(defun elpamr--run-tar (working-dir out-file dir-to-archive)
+  "Run tar in order to archive DIR-TO-ARCHIVE into OUT-FILE.
+Paths are relative to WORKING-DIR."
+  (let* ((exclude-opts (mapcar (lambda (s) (concat "--exclude=" s))
+                               elpamr-tar-command-exclude-patterns))
+         ;; create tar using GNU tar
+         (tar-args
+          `("cf" ,out-file
+            ,@exclude-opts
+            ;; tar 1.14 NEWS,
+            ;; @see https://git.savannah.gnu.org/cgit/tar.git/plain/NEWS?id=release_1_14
+            ;; * New option --format allows to select the output archive format
+            ;; * The default output format can be selected at configuration time
+            ;;   by presetting the environment variable DEFAULT_ARCHIVE_FORMAT.
+            ;;   Allowed values are GNU, V7, OLDGNU and POSIX.
+            ,@(unless (elpamr--is-mac) '("--format=gnu"))
+            "-C" ,working-dir
+            "--" ,dir-to-archive))
+         ;; BSD tar need set environment variable COPYFILE_DISABLE
+         (process-environment (if (elpamr--is-mac)
+                                  (cons "COPYFILE_DISABLE=" process-environment)
+                                process-environment)))
+    (apply #'call-process
+           (elpamr--executable-find "tar") nil
+           "*elpa-mirror tar output*" nil
+           tar-args)))
+
 ;;;###autoload
 (defun elpamr-version ()
   "Current version."
@@ -205,11 +232,6 @@ will be deleted and recreated."
          tar-cmd
          (pkg-dir (file-truename package-user-dir))
          (dirs (directory-files pkg-dir))
-         (exclude-opts (concat " "
-                               (mapconcat (lambda (s) (format "--exclude=\"%s\"" s))
-                                          elpamr-tar-command-exclude-patterns
-                                          " ")
-                               " "))
          (cnt 0))
 
     ;; Since Emacs 27, `package-initialize' is optional.
@@ -252,30 +274,9 @@ will be deleted and recreated."
       (dolist (dir dirs)
         (unless (or (member dir '("archives" "." ".."))
                     (not (elpamr--extract-info-from-dir dir)))
-          ;; create tar using GNU tar
-          ;; BSD tar need set environment variable COPYFILE_DISABLE
-          (setq tar-cmd
-                (concat (if (elpamr--is-mac) "COPYFILE_DISABLE=\"\" " "")
-                        (elpamr--executable-find "tar")
-                        " cf "
-                        (elpamr--fullpath output-directory dir)
-                        ".tar"
-                        exclude-opts
-                        ;; tar 1.14 NEWS,
-                        ;; @see https://git.savannah.gnu.org/cgit/tar.git/plain/NEWS?id=release_1_14
-                        ;; * New option --format allows to select the output archive format
-                        ;; * The default output format can be selected at configuration time
-                        ;;   by presetting the environment variable DEFAULT_ARCHIVE_FORMAT.
-                        ;;   Allowed values are GNU, V7, OLDGNU and POSIX.
-                        (if (elpamr--is-mac) "" " --format=gnu ")
-                        " -C "
-                        pkg-dir
-                        " "
-                        dir))
-
-          ;; for windows
-          (if elpamr-debug (message "tar-cmd=%s" tar-cmd))
-          (shell-command tar-cmd)
+          (elpamr--run-tar pkg-dir
+                           (concat (elpamr--fullpath output-directory dir) ".tar")
+                           dir)
           (setq cnt (1+ cnt))
           (message "Creating *.tar ... %d%%" (/ (* cnt 100) (length dirs)))))
 


### PR DESCRIPTION
This pull request is the same as https://github.com/redguardtoo/elpa-mirror/pull/28, except I've rebased it on the current master and fixed the condition for `--format=gnu`.