### PR TITLE
Improve reproducibility

### DIFF
--- a/elpa-mirror.el
+++ b/elpa-mirror.el
@@ -238,14 +238,20 @@ will be deleted and recreated."
     ;; but we still need it to initialize `package-alist'.
     (unless package-alist (package-initialize))
 
-    ;; quoted from manual:
+    ;; Quote from manual about package-alist:
     ;;   Alist of all packages available for activation.
     ;;   Each element has the form (PKG . DESCS), where PKG is a package
     ;;   name (a symbol) and DESCS is a non-empty list of `package-desc' structure,
     ;;   sorted by decreasing versions.
-    (dolist (pkg package-alist)
-      (setq item (elpamr--create-one-item-for-archive-contents pkg))
-      (if item (push item final-pkg-list)))
+    ;; Sorted for reproducibility.
+    (setq final-pkg-list
+          (let ((sorted-package-alist
+                 (sort (copy-sequence package-alist)
+                       (lambda (a b)
+                         (string< (symbol-name (car a))
+                                  (symbol-name (car b)))))))
+            (delq nil (mapcar #'elpamr--create-one-item-for-archive-contents
+                              sorted-package-alist))))
 
     ;; set output directory
     (setq output-directory

--- a/elpa-mirror.el
+++ b/elpa-mirror.el
@@ -196,6 +196,15 @@ Paths are relative to WORKING-DIR."
             ;;   by presetting the environment variable DEFAULT_ARCHIVE_FORMAT.
             ;;   Allowed values are GNU, V7, OLDGNU and POSIX.
             ,@(unless (elpamr--is-mac) '("--format=gnu"))
+            ;; Improve reproducibility by not storing unnecessary metadata.
+            ;; These options are enough for archives in the GNU format, but if
+            ;; we ever switch to PAX, we'll need to add more (see
+            ;; <http://h2.jaguarpaw.co.uk/posts/reproducible-tar/> and
+            ;; <https://www.gnu.org/software/tar/manual/html_node/PAX-keywords.html>).
+            ,@(unless (elpamr--is-mac)
+                '("--sort=name"
+                  "--owner=root:0" "--group=root:0"
+                  "--mtime=1970-01-01 00:00:00 UTC"))
             "-C" ,working-dir
             "--" ,dir-to-archive))
          ;; BSD tar need set environment variable COPYFILE_DISABLE

--- a/elpa-mirror.el
+++ b/elpa-mirror.el
@@ -236,9 +236,7 @@ will be used as mirror package's output directory:
 When RECREATE-DIRECTORY is non-nil, OUTPUT-DIRECTORY
 will be deleted and recreated."
   (interactive)
-  (let* (item
-         final-pkg-list
-         tar-cmd
+  (let* (final-pkg-list
          (pkg-dir (file-truename package-user-dir))
          (dirs (directory-files pkg-dir))
          (cnt 0))


### PR DESCRIPTION
The aim of this pull request is to improve the reproducibility of directories generated by `elpa-mirror`. This means that directories generated from the same packages at the same versions should be identical even if the packages were installed at different times, by different users, or on different computers.

This will make it easier to compare generated directories. Depending on how the users synchronizes their repository, it will also reduce Dropbox/Syncthing network churn or git repo size.

The way this is done is by sorting the list of packages, and by passing additional options to tar to force the stored user to `root` and the mtime to `0`. This is for GNU tar only, as BSD tar doesn't support all the necessary features.