### PR TITLE
Better error detection and more detailed logging

### DIFF
--- a/README.org
+++ b/README.org
@@ -63,5 +63,5 @@ Insert below code into =.emacs=:
              '("myelpa" . "https://raw.githubusercontent.com/redguardtoo/myelpa/master/"))
 #+end_src
 * Report bug
-- Insert =(setq elpamr-debug t)= into =.emacs=
-- Reproduce bug and report at [[https://github.com/redguardtoo/elpa-mirror]]
+
+Reproduce the bug, report it at [[https://github.com/redguardtoo/elpa-mirror]], and attach the contents of the =*elpa-mirror log*= buffer.


### PR DESCRIPTION
This pull request

* Removes the `elpamr-debug` variable and instead makes `elpa-mirror` always log a lot of detail to a background buffer called `*elpa-mirror log*`. This buffer also contains `tar`'s output, so it should make it easier to see potential errors output by `tar` and correlate them with what `elpa-mirror` was doing.
* Makes messages and log entries more detailed in general.
* Detects errors when `cygpath` and `tar` are run. If an error happens, `elpa-mirror` stops immediately and reports it to the user.
* Removes usage of the shell in `elpamr--fullpath`. This lets us detect errors, as well as prevent possible problems in case the path contains special characters that could get mangled by the shell. It's also a good programming practice not to use an additional shell process when its features aren't needed.