### PR TITLE
Add __pycache__ to exclude patterns

### DIFF
--- a/elpa-mirror.el
+++ b/elpa-mirror.el
@@ -79,7 +79,8 @@
     "*.so"
     "*.dylib"
     "*.dll"
-    "*/bin/")
+    "*/bin/"
+    "__pycache__")
   "Exclude glob patterns passed to tar command's \"--exclude\" option.
 \"company-*/bin/\" matches \"bin\" sub-directory of package company.
 \"*/bin/*\" matches any file in \"bin\" sub-directory of any package."


### PR DESCRIPTION
This pull request makes `elpa-mirror` ignore temporary cache files created by Python.